### PR TITLE
add GHS/RH850 FPU support.

### DIFF
--- a/freertos/portable/GHS/RH850/port.c
+++ b/freertos/portable/GHS/RH850/port.c
@@ -34,7 +34,7 @@
 #define portPRELOAD_REGISTERS   ( 0 )
 
 /* Constants required to set up the initial stack. */
-#define portINITIAL_PSW     ( 0x00008000 ) /* PSW.EBV bit */
+#define portINITIAL_PSW     ( 0x00018000 ) /* PSW.EBV bit and PSW.CU bit */
 
 /* Counts the interrupt nesting depth. A context switch is only performed
  * if the nesting depth is 0. */
@@ -74,28 +74,29 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 {
     /* Simulate the stack frame as it would be created by a context switch
      * interrupt. */
-    pxTopOfStack -= 30;
+    pxTopOfStack -= 31;
     #if ( portPRELOAD_REGISTERS == 1 )
     {
-        pxTopOfStack[ 29 ] = ( StackType_t ) prvTaskExitError;  /* R31 (LP) */
-        pxTopOfStack[ 28 ] = ( StackType_t ) pvParameters;      /* R6       */
-        pxTopOfStack[ 27 ] = ( StackType_t ) 0x07070707;        /* R7       */
-        pxTopOfStack[ 26 ] = ( StackType_t ) 0x08080808;        /* R8       */
-        pxTopOfStack[ 25 ] = ( StackType_t ) 0x09090909;        /* R9       */
-        pxTopOfStack[ 24 ] = ( StackType_t ) 0x10101010;        /* R10      */
-        pxTopOfStack[ 23 ] = ( StackType_t ) 0x11111111;        /* R11      */
-        pxTopOfStack[ 22 ] = ( StackType_t ) 0x12121212;        /* R12      */
-        pxTopOfStack[ 21 ] = ( StackType_t ) 0x13131313;        /* R13      */
-        pxTopOfStack[ 20 ] = ( StackType_t ) 0x14141414;        /* R14      */
-        pxTopOfStack[ 19 ] = ( StackType_t ) 0x15151515;        /* R15      */
-        pxTopOfStack[ 18 ] = ( StackType_t ) 0x16161616;        /* R16      */
-        pxTopOfStack[ 17 ] = ( StackType_t ) 0x17171717;        /* R17      */
-        pxTopOfStack[ 16 ] = ( StackType_t ) 0x18181818;        /* R18      */
-        pxTopOfStack[ 15 ] = ( StackType_t ) 0x19191919;        /* R19      */
-        pxTopOfStack[ 14 ] = ( StackType_t ) 0x01010101;        /* R1       */
-        pxTopOfStack[ 13 ] = ( StackType_t ) 0x02020202;        /* R2       */
-        pxTopOfStack[ 12 ] = ( StackType_t ) portINITIAL_PSW;   /* EIPSW    */
-        pxTopOfStack[ 11 ] = ( StackType_t ) pxCode;            /* EIPC     */
+        pxTopOfStack[ 30 ] = ( StackType_t ) prvTaskExitError;  /* R31 (LP) */
+        pxTopOfStack[ 29 ] = ( StackType_t ) pvParameters;      /* R6       */
+        pxTopOfStack[ 28 ] = ( StackType_t ) 0x07070707;        /* R7       */
+        pxTopOfStack[ 27 ] = ( StackType_t ) 0x08080808;        /* R8       */
+        pxTopOfStack[ 26 ] = ( StackType_t ) 0x09090909;        /* R9       */
+        pxTopOfStack[ 25 ] = ( StackType_t ) 0x10101010;        /* R10      */
+        pxTopOfStack[ 24 ] = ( StackType_t ) 0x11111111;        /* R11      */
+        pxTopOfStack[ 23 ] = ( StackType_t ) 0x12121212;        /* R12      */
+        pxTopOfStack[ 22 ] = ( StackType_t ) 0x13131313;        /* R13      */
+        pxTopOfStack[ 21 ] = ( StackType_t ) 0x14141414;        /* R14      */
+        pxTopOfStack[ 20 ] = ( StackType_t ) 0x15151515;        /* R15      */
+        pxTopOfStack[ 19 ] = ( StackType_t ) 0x16161616;        /* R16      */
+        pxTopOfStack[ 18 ] = ( StackType_t ) 0x17171717;        /* R17      */
+        pxTopOfStack[ 17 ] = ( StackType_t ) 0x18181818;        /* R18      */
+        pxTopOfStack[ 16 ] = ( StackType_t ) 0x19191919;        /* R19      */
+        pxTopOfStack[ 15 ] = ( StackType_t ) 0x01010101;        /* R1       */
+        pxTopOfStack[ 14 ] = ( StackType_t ) 0x02020202;        /* R2       */
+        pxTopOfStack[ 13 ] = ( StackType_t ) portINITIAL_PSW;   /* EIPSW    */
+        pxTopOfStack[ 12 ] = ( StackType_t ) pxCode;            /* EIPC     */
+        pxTopOfStack[ 11 ] = ( StackType_t ) 0x12121212;        /* FPSR     */
         pxTopOfStack[ 10 ] = ( StackType_t ) 0x20202020;        /* R20      */
         pxTopOfStack[ 9 ] = ( StackType_t ) 0x21212121;         /* R21      */
         pxTopOfStack[ 8 ] = ( StackType_t ) 0x22222222;         /* R22      */
@@ -110,10 +111,11 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     }
     #else
     {
-        pxTopOfStack[ 29 ] = ( StackType_t ) prvTaskExitError;  /* R31 (LP) */
-        pxTopOfStack[ 28 ] = ( StackType_t ) pvParameters;      /* R6       */
-        pxTopOfStack[ 12 ] = ( StackType_t ) portINITIAL_PSW;   /* EIPSW    */
-        pxTopOfStack[ 11 ] = ( StackType_t ) pxCode;            /* EIPC     */
+        pxTopOfStack[ 30 ] = ( StackType_t ) prvTaskExitError;  /* R31 (LP) */
+        pxTopOfStack[ 29 ] = ( StackType_t ) pvParameters;      /* R6       */
+        pxTopOfStack[ 13 ] = ( StackType_t ) portINITIAL_PSW;   /* EIPSW    */
+        pxTopOfStack[ 12 ] = ( StackType_t ) pxCode;            /* EIPC     */
+        pxTopOfStack[ 11 ] = ( StackType_t ) 0x00000000;        /* FPSR     */
     }
     #endif
 

--- a/freertos/portable/GHS/RH850/portasm.s
+++ b/freertos/portable/GHS/RH850/portasm.s
@@ -47,7 +47,8 @@ _vPortStartFirstTask:
 
     popsp r20 - r30                     # Restore General Purpose Register (callee save register)
 
-    popsp r6 - r7
+    popsp r6 - r8
+    ldsr r8, FPSR                       # Restore FPSR
     ldsr r7, EIPC                       # Restore EIPC
     ldsr r6, EIPSW                      # Restore EIPSW
 
@@ -69,7 +70,8 @@ _vPortYieldHandler:
 
     stsr EIPSW, r6                      # Save EIPSW
     stsr EIPC, r7                       # Save EIPC
-    pushsp r6 - r7
+    stsr FPSR, r8                       # Save FPSR
+    pushsp r6 - r8
 
     pushsp r20 - r30                    # Save General Purpose Register (callee save register)
 
@@ -85,7 +87,8 @@ _vPortYieldHandler:
 
     popsp r20 - r30                     # Restore General Purpose Register (callee save register)
 
-    popsp r6 - r7
+    popsp r6 - r8
+    ldsr r8, FPSR                       # Restore FPSR
     ldsr r7, EIPC                       # Restore EIPC
     ldsr r6, EIPSW                      # Restore EIPSW
 
@@ -107,7 +110,8 @@ _vISRWrapper:
 
     stsr EIPSW, r6                      # Save EIPSW
     stsr EIPC, r7                       # Save EIPC
-    pushsp r6 - r7
+    stsr FPSR, r8                       # Save FPSR
+    pushsp r6 - r8
 
     mov _xInterruptNesting, r6
     ld.w 0[r6], r7
@@ -161,7 +165,8 @@ bb:                                     #     else
     ld.w 0[r8], r9                      #         SP = pxCurrentTCB->pxTopOfStack
     ld.w 0[r9], sp                      #     }
 cc:                                     # }
-    popsp r6 - r7
+    popsp r6 - r8
+    ldsr r8, FPSR                       # Restore FPSR
     ldsr r7, EIPC                       # Restore EIPC
     ldsr r6, EIPSW                      # Restore EIPSW
 


### PR DESCRIPTION
This is a FPU support for GHS/RH850 (F1KM).

Changes:

- port.c: changed portINITIAL_PSW value to enable CU bit
- port.c: added register space for FPSR added
- portasm.s: added FPSR save/restore routines